### PR TITLE
Update calibration.py

### DIFF
--- a/wirc_drp/utils/calibration.py
+++ b/wirc_drp/utils/calibration.py
@@ -103,7 +103,10 @@ def masterFlat(flat_list, master_dark_fname, normalize = 'median', local_sig_bad
         except:
             print("Some error. Skipping file {}".format(i))   
     #Median combine frames
-    flat = np.median(foo, axis = 0)
+    try:
+        flat = np.median(foo, axis = 0)
+    except:
+        raise ValueError('No flat images found in input list, or all eliminated by the min_flux requirement\nTry lowering min_flux threshold')
 
     #Filter bad pixels
     #bad_px = sigma_clip(flat, sigma = sig_bad_pix) #old and bad


### PR DESCRIPTION
Ran into this error processing my data recently.  Turns out I started taking flats too early at dawn, so the flux was below the min_flux threshold.  There should be some notice given to the user as to the source of the error, otherwise you just get a useless numpy error about numpy.bool not supporting item assignment.