### PR TITLE
updates for modern photutils, numpy

### DIFF
--- a/wirc_drp/utils/spec_utils.py
+++ b/wirc_drp/utils/spec_utils.py
@@ -26,7 +26,6 @@ from astropy.convolution import Gaussian1DKernel, Box1DKernel, convolve
 from astropy.io import fits as f
 from astropy import stats
 
-from photutils import RectangularAperture, aperture_photometry,make_source_mask
 
 #From other packages
 from wirc_drp.utils.image_utils import locationInIm, shift_and_subtract_background, fit_and_subtract_background, findTrace
@@ -34,6 +33,10 @@ from wirc_drp.masks.wircpol_masks import *
 from wirc_drp.utils import image_utils
 
 from astropy.stats import sigma_clipped_stats
+
+from photutils import RectangularAperture, aperture_photometry
+from photutils.segmentation import SegmentationImage, detect
+
 
 #Import for vip functions
 import warnings
@@ -2083,7 +2086,10 @@ def broadband_aperture_photometry(thumbnails, width_scale = 5, source_offsets = 
             plt.show()
 
         if bkg_method == 'median_mask':
-            mask = make_source_mask(thumbnail,snr=3,npixels=5,dilate_size=11)
+            im_data=copy.deepcopy(thumbnail)
+            imthres=detect.detect_threshold(im_data,3)
+            im_data[im_data < imthres]=0
+            mask = SegmentationImage(im_data).make_source_mask(size=11)            
             mean,median,std = sigma_clipped_stats(thumbnail,sigma=3.0,mask=mask)
             thumbnail = thumbnail - median
 

--- a/wirc_drp/wirc_object.py
+++ b/wirc_drp/wirc_object.py
@@ -1374,16 +1374,29 @@ class wircpol_source(object):
         """
         locs = [int(self.pos[0]),int(self.pos[1])]
 
-        self.trace_images = np.array(image_utils.cutout_trace_thumbnails(image, np.expand_dims([locs, self.slit_pos],axis=0), flip=False,filter_name = filter_name,
-            cutout_size= cutout_size, sub_bar = sub_bar, verbose=verbose)[0])
-        try:
-            self.trace_images_DQ = np.array(image_utils.cutout_trace_thumbnails(image_DQ, np.expand_dims([locs, self.slit_pos],axis=0), flip=False,filter_name = filter_name,
-            cutout_size= cutout_size, sub_bar = False, verbose = verbose)[0])
-        except:
-            if verbose:
-                print("Could not cutout data quality (DQ) thumbnails. Assuming everything is good.")
-            self.trace_images_DQ = np.ndarray.astype(copy.deepcopy(self.trace_images*0),int)
+        if self.slit_pos=='slitless':
+        
+            self.trace_images = np.array(image_utils.cutout_trace_thumbnails(image, np.expand_dims([locs],axis=0), flip=False,filter_name = filter_name,
+                cutout_size= cutout_size, sub_bar = sub_bar, verbose=verbose)[0])
+            try:
+                self.trace_images_DQ = np.array(image_utils.cutout_trace_thumbnails(image_DQ, np.expand_dims([locs],axis=0), flip=False,filter_name = filter_name,
+                cutout_size= cutout_size, sub_bar = False, verbose = verbose)[0])
+            except:
+                if verbose:
+                    print("Could not cutout data quality (DQ) thumbnails. Assuming everything is good.")
+                self.trace_images_DQ = np.ndarray.astype(copy.deepcopy(self.trace_images*0),int)
+        else:
+            self.trace_images = np.array(image_utils.cutout_trace_thumbnails(image, np.expand_dims([locs, self.slit_pos],axis=0), flip=False,filter_name = filter_name,
+                cutout_size= cutout_size, sub_bar = sub_bar, verbose=verbose)[0])
+            try:
+                self.trace_images_DQ = np.array(image_utils.cutout_trace_thumbnails(image_DQ, np.expand_dims([locs, self.slit_pos],axis=0), flip=False,filter_name = filter_name,
+                cutout_size= cutout_size, sub_bar = False, verbose = verbose)[0])
+            except:
+                if verbose:
+                    print("Could not cutout data quality (DQ) thumbnails. Assuming everything is good.")
+                self.trace_images_DQ = np.ndarray.astype(copy.deepcopy(self.trace_images*0),int)
 
+            
         # if replace_bad_pixels:
         #     #iterate through the 4 thumbnails
         #     for i in range(len(self.trace_images)):
@@ -1417,8 +1430,12 @@ class wircpol_source(object):
             LL_pca_cutouts = []
 
             for i in range(len(ref_lib)):
-                cutouts = np.array(image_utils.cutout_trace_thumbnails(fits.getdata(ref_lib[i]), np.expand_dims([locs, self.slit_pos],axis=0), flip=False,filter_name = filter_name,   
-                                        cutout_size= cutout_size, sub_bar = sub_bar, verbose=verbose)[0]) 
+                if self.slit_pos=='slitless':
+                    cutouts = np.array(image_utils.cutout_trace_thumbnails(fits.getdata(ref_lib[i]), np.expand_dims([locs],axis=0), flip=False,filter_name = filter_name,   
+                                                                           cutout_size= cutout_size, sub_bar = sub_bar, verbose=verbose)[0])
+                else:
+                    cutouts = np.array(image_utils.cutout_trace_thumbnails(fits.getdata(ref_lib[i]), np.expand_dims([locs, self.slit_pos],axis=0), flip=False,filter_name = filter_name,   
+                                                                           cutout_size= cutout_size, sub_bar = sub_bar, verbose=verbose)[0]) 
 
                 UL_pca_cutouts.append(cutouts[0])
                 LR_pca_cutouts.append(cutouts[1])
@@ -1447,9 +1464,13 @@ class wircpol_source(object):
                         bad_pix_map = self.trace_images_DQ[i].astype(bool)  
                         self.trace_bkg[i] = calibration.cleanBadPix(self.trace_bkg[i], bad_pix_map, replacement_box = box_size)
 
-        elif bkg_image is not None:   
-            self.trace_bkg = np.array(image_utils.cutout_trace_thumbnails(bkg_image, np.expand_dims([locs, self.slit_pos],axis=0), flip=False,filter_name = filter_name,   
-                                cutout_size= cutout_size, sub_bar = sub_bar, verbose=verbose)[0])   
+        elif bkg_image is not None:
+            if self.slit_pos=='slitless':
+                self.trace_bkg = np.array(image_utils.cutout_trace_thumbnails(bkg_image, np.expand_dims([locs],axis=0), flip=False,filter_name = filter_name,   
+                                                                              cutout_size= cutout_size, sub_bar = sub_bar, verbose=verbose)[0])
+            else:
+                self.trace_bkg = np.array(image_utils.cutout_trace_thumbnails(bkg_image, np.expand_dims([locs, self.slit_pos],axis=0), flip=False,filter_name = filter_name,   
+                                                                              cutout_size= cutout_size, sub_bar = sub_bar, verbose=verbose)[0])   
             if replace_bad_pixels: 
                 #check method   
                 if method == 'interpolate': 
@@ -2141,8 +2162,12 @@ class wircpol_source(object):
 
         locs = [int(self.pos[0]),int(self.pos[1])]
 
-        self.trace_bkg = np.array(image_utils.cutout_trace_thumbnails(bkg_image, np.expand_dims([locs, self.slit_pos],axis=0), flip=False,
-            filter_name = filter_name, cutout_size= cutout_size, sub_bar = sub_bar, verbose=verbose)[0])   
+        if self.slit_pos=='slitless':
+            self.trace_bkg = np.array(image_utils.cutout_trace_thumbnails(bkg_image, np.expand_dims([locs],axis=0), flip=False,
+                                                                          filter_name = filter_name, cutout_size= cutout_size, sub_bar = sub_bar, verbose=verbose)[0])
+        else:
+            self.trace_bkg = np.array(image_utils.cutout_trace_thumbnails(bkg_image, np.expand_dims([locs, self.slit_pos],axis=0), flip=False,
+                                                                          filter_name = filter_name, cutout_size= cutout_size, sub_bar = sub_bar, verbose=verbose)[0])   
 
 
         if replace_bad_pixels:
@@ -2220,12 +2245,19 @@ class wircspec_source(object):
         """
 
         locs = [int(self.pos[0]),int(self.pos[1])]
-        self.trace_images = np.array(image_utils.cutout_trace_thumbnails(image, np.expand_dims([locs, self.slit_pos],axis=0), flip=flip,filter_name = filter_name, sub_bar = sub_bar, mode = 'spec', cutout_size = cutout_size, verbose=verbose)[0])
+        if self.slit_pos=='slitless':
+            self.trace_images = np.array(image_utils.cutout_trace_thumbnails(image, np.expand_dims([locs],axis=0), flip=flip,filter_name = filter_name, sub_bar = sub_bar, mode = 'spec', cutout_size = cutout_size, verbose=verbose)[0])
+        else:
+            self.trace_images = np.array(image_utils.cutout_trace_thumbnails(image, np.expand_dims([locs, self.slit_pos],axis=0), flip=flip,filter_name = filter_name, sub_bar = sub_bar, mode = 'spec', cutout_size = cutout_size, verbose=verbose)[0])
         if image_DQ is not None:
 
             try:
-                self.trace_images_DQ = np.array(image_utils.cutout_trace_thumbnails(image_DQ, np.expand_dims([locs, self.slit_pos],axis=0), flip=flip,\
-                                        filter_name = filter_name, sub_bar = sub_bar, mode = 'spec', cutout_size = cutout_size, verbose = verbose)[0])
+                if self.slit_pos=='slitless':
+                    self.trace_images_DQ = np.array(image_utils.cutout_trace_thumbnails(image_DQ, np.expand_dims([locs],axis=0), flip=flip,\
+                                                                                        filter_name = filter_name, sub_bar = sub_bar, mode = 'spec', cutout_size = cutout_size, verbose = verbose)[0])
+                else:
+                    self.trace_images_DQ = np.array(image_utils.cutout_trace_thumbnails(image_DQ, np.expand_dims([locs, self.slit_pos],axis=0), flip=flip,\
+                                                                                        filter_name = filter_name, sub_bar = sub_bar, mode = 'spec', cutout_size = cutout_size, verbose = verbose)[0])
             except:
                 if verbose:
                     print("Could not cutout data quality (DQ) thumbnails. Assuming everything is good.")


### PR DESCRIPTION
Photutils changed their image segmentation tool that the extraction here was relying on.  This is a bit of a kludge, but it now uses the modern photutils tooling for the same thumbnail masking that was being done before.  This closes Issue #34 

In addition, 'slitless' wircpol_objects were running afoul of numpy dimension expansion in various places in source/spectral extraction.  As we don't use wircpol in slit mode anymore (given how hard it is to make sure the source is in said slit), I put in a workaround for slitless extractions that just skips the offending statement and moves on.  The behavior should be the same if one of the integer slit values is used in the call, although frankly I'm not really sure how it didn't fail originally. Perhaps it did, but more politely.